### PR TITLE
Allow URLs to be shared for specific API methods

### DIFF
--- a/dist/css/screen.css
+++ b/dist/css/screen.css
@@ -1483,3 +1483,7 @@
   outline-color: #cc0000;
   background-color: #f2dede;
 }
+.graph_container {
+  width: 90%; 
+  height: 30em; 
+}

--- a/dist/footer.htm
+++ b/dist/footer.htm
@@ -19,6 +19,7 @@
     <script src='lib/marked.js' type='text/javascript'></script>
     <script src='lib/swagger-oauth.js' type='text/javascript'></script>
     <script src='lib/gen-swagger.js' type='text/javascript'></script>
+    <script src='lib/apigee.js' type='text/javascript'></script>
     <script src='lib/swagger-ui.js' type='text/javascript'></script>
   </body>
 </html>

--- a/dist/footer.htm
+++ b/dist/footer.htm
@@ -18,9 +18,13 @@
     <script src='lib/jsoneditor.min.js' type='text/javascript'></script>
     <script src='lib/marked.js' type='text/javascript'></script>
     <script src='lib/swagger-oauth.js' type='text/javascript'></script>
+    <script src="lib/cookies.js"></script>
+    <script src="lib/cors.js"></script>
     <script src='lib/gen-swagger.js' type='text/javascript'></script>
     <script src='lib/apigee.js' type='text/javascript'></script>
     <script src='lib/swagger-ui.js' type='text/javascript'></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/flot/0.8.2/jquery.flot.min.js" type="text/javascript"></script>
+    <script src='lib/jquery.flot.axislabels.js' type='text/javascript'></script>
   </body>
 </html>
 

--- a/dist/index.php
+++ b/dist/index.php
@@ -4,6 +4,8 @@
    <ul class="nav nav-sidebar" id="listprime">
    </ul>
 </div>
+<div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2" id="options-menu">
+</div>
 <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main swagger-ui-wrap">
 <?php
    if(isset($_SESSION['status'])){

--- a/dist/lib/apigee.js
+++ b/dist/lib/apigee.js
@@ -3,6 +3,19 @@ function collect_metrics(target_url){
 	if (target_url.indexOf("apigee") == -1) {
 		$("#swagger-ui-container").append('<div class="alert alert-warning"><strong>Failure</strong> Not an Apigee API, no analytics available</div>');
 	}else{
-	console.log(target_url);
+		var key = "Basic " + getCookie("apigee_key");
+		var target = getCookie("apigee_url");
+		makeCorsRequest(target, key, function(val) {
+				console.log(val);
+				var results = val["environments"][0]["dimensions"];
+				for (var count = 0; count < results.length; count++){
+					var current = results[count]["name"].toUpperCase()
+					var url = target_url.toUpperCase();
+					if(url.indexOf(current) !== -1){
+						$("#swagger-ui-container").append(JSON.stringify(results[count]));
+					}
+				}
+				});
+
 	}
 }

--- a/dist/lib/apigee.js
+++ b/dist/lib/apigee.js
@@ -1,21 +1,45 @@
 function collect_metrics(target_url){
 	document.getElementById("swagger-ui-container").innerHTML = "";
-	if (target_url.indexOf("apigee") == -1) {
+	if (!getCookie("apigee_key")){
+		$("#swagger-ui-container").append('<div class="alert alert-warning"><strong>Failure</strong> No Apigee key set, go to the <a href="options.php">settings page</a> to set one.</div>');
+	
+	}else if (target_url.indexOf("apigee") == -1) {
 		$("#swagger-ui-container").append('<div class="alert alert-warning"><strong>Failure</strong> Not an Apigee API, no analytics available</div>');
 	}else{
 		var key = "Basic " + getCookie("apigee_key");
 		var target = getCookie("apigee_url");
-		makeCorsRequest(target, key, function(val) {
-				console.log(val);
+		var options = {
+        axisLabels: {
+            show: true
+        },
+        xaxes: [{
+            axisLabel: 'Days',
+        }],
+        yaxes: [{
+            position: 'left',
+            axisLabel: 'Response time (milliseconds)',
+        }]
+    };
+		makeCorsRequest(target, key, "apigee", function(val) {
 				var results = val["environments"][0]["dimensions"];
 				for (var count = 0; count < results.length; count++){
 					var current = results[count]["name"].toUpperCase()
 					var url = target_url.toUpperCase();
 					if(url.indexOf(current) !== -1){
-						$("#swagger-ui-container").append(JSON.stringify(results[count]));
+						var set = results[count]["metrics"][1]["values"];
+						var arr = [];
+						for (var subarray = 0; subarray < set.length; subarray++){
+							var item = [];
+							item[0] = subarray; 
+							item[1] = set[subarray]["value"]; 
+							console.log(item);
+							arr.push(item);
+						}
+						$("#swagger-ui-container").append('<div id="graph_container" class="graph_container"></div>');
+						$.plot($("#graph_container"), [arr], options); 
 					}
 				}
-				});
+		});
 
 	}
 }

--- a/dist/lib/apigee.js
+++ b/dist/lib/apigee.js
@@ -1,45 +1,45 @@
-function collect_metrics(target_url){
-	document.getElementById("swagger-ui-container").innerHTML = "";
-	if (!getCookie("apigee_key")){
-		$("#swagger-ui-container").append('<div class="alert alert-warning"><strong>Failure</strong> No Apigee key set, go to the <a href="options.php">settings page</a> to set one.</div>');
-	
-	}else if (target_url.indexOf("apigee") == -1) {
-		$("#swagger-ui-container").append('<div class="alert alert-warning"><strong>Failure</strong> Not an Apigee API, no analytics available</div>');
-	}else{
-		var key = "Basic " + getCookie("apigee_key");
-		var target = getCookie("apigee_url");
-		var options = {
-        axisLabels: {
-            show: true
-        },
-        xaxes: [{
-            axisLabel: 'Days',
-        }],
-        yaxes: [{
-            position: 'left',
-            axisLabel: 'Response time (milliseconds)',
-        }]
-    };
-		makeCorsRequest(target, key, "apigee", function(val) {
-				var results = val["environments"][0]["dimensions"];
-				for (var count = 0; count < results.length; count++){
-					var current = results[count]["name"].toUpperCase()
-					var url = target_url.toUpperCase();
-					if(url.indexOf(current) !== -1){
-						var set = results[count]["metrics"][1]["values"];
-						var arr = [];
-						for (var subarray = 0; subarray < set.length; subarray++){
-							var item = [];
-							item[0] = subarray; 
-							item[1] = set[subarray]["value"]; 
-							console.log(item);
-							arr.push(item);
-						}
-						$("#swagger-ui-container").append('<div id="graph_container" class="graph_container"></div>');
-						$.plot($("#graph_container"), [arr], options); 
-					}
-				}
-		});
+function collect_metrics(target_url) {
+    document.getElementById("swagger-ui-container").innerHTML = "";
+    if (!getCookie("apigee_key")) {
+        $("#swagger-ui-container").append('<div class="alert alert-warning"><strong>Failure</strong> No Apigee key set, go to the <a href="options.php">settings page</a> to set one.</div>');
 
-	}
+    } else if (target_url.indexOf("apigee") == -1) {
+        $("#swagger-ui-container").append('<div class="alert alert-warning"><strong>Failure</strong> Not an Apigee API, no analytics available</div>');
+    } else {
+        var key = "Basic " + getCookie("apigee_key");
+        var target = getCookie("apigee_url");
+        var options = {
+            axisLabels: {
+                show: true
+            },
+            xaxes: [{
+                axisLabel: 'Days',
+            }],
+            yaxes: [{
+                position: 'left',
+                axisLabel: 'Response time (milliseconds)',
+            }]
+        };
+        makeCorsRequest(target, key, "apigee", function(val) {
+            var results = val["environments"][0]["dimensions"];
+            for (var count = 0; count < results.length; count++) {
+                var current = results[count]["name"].toUpperCase()
+                var url = target_url.toUpperCase();
+                if (url.indexOf(current) !== -1) {
+                    var set = results[count]["metrics"][1]["values"];
+                    var arr = [];
+                    for (var subarray = 0; subarray < set.length; subarray++) {
+                        var item = [];
+                        item[0] = subarray;
+                        item[1] = set[subarray]["value"];
+                        console.log(item);
+                        arr.push(item);
+                    }
+                    $("#swagger-ui-container").append('<div id="graph_container" class="graph_container"></div>');
+                    $.plot($("#graph_container"), [arr], options);
+                }
+            }
+        });
+
+    }
 }

--- a/dist/lib/apigee.js
+++ b/dist/lib/apigee.js
@@ -1,0 +1,8 @@
+function collect_metrics(target_url){
+	document.getElementById("swagger-ui-container").innerHTML = "";
+	if (target_url.indexOf("apigee") == -1) {
+		$("#swagger-ui-container").append('<div class="alert alert-warning"><strong>Failure</strong> Not an Apigee API, no analytics available</div>');
+	}else{
+	console.log(target_url);
+	}
+}

--- a/dist/lib/cookies.js
+++ b/dist/lib/cookies.js
@@ -38,11 +38,20 @@ $(function() {
 });
 
 $(function() {
+  $('#apigee').on("submit",function(e) {
+    e.preventDefault();
+    createCookie("apigee_key",document.getElementById("base64").value,30);
+    createCookie("apigee_url",document.getElementById("target").value,30);
+    $("#submit").remove()
+    $("#apigee").append('<div class="alert alert-info"><strong>Updated!</strong></div>');
+  });
+});
+
+$(function() {
   $('#clear').on("click", function(e) {
    e.preventDefault();
    eraseCookie("swaggercookie_url");
    eraseCookie("swaggercookie_key");
-   $("#clear").remove()
-   $("#swaggerhub").append('<div class="alert alert-info"><strong>Cleared!</strong></div>');
+   eraseCookie("apigee_key");
   });
 });

--- a/dist/lib/cookies.js
+++ b/dist/lib/cookies.js
@@ -1,76 +1,75 @@
-function createCookie(name,value,days) {
+function createCookie(name, value, days) {
     if (days) {
         var date = new Date();
-        date.setTime(date.getTime()+(days*24*60*60*1000));
-        var expires = "; expires="+date.toGMTString();
-    }
-    else var expires = "";
-    document.cookie = name+"="+value+expires+"; path=/";
+        date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+        var expires = "; expires=" + date.toGMTString();
+    } else var expires = "";
+    document.cookie = name + "=" + value + expires + "; path=/";
 }
 
 function getCookie(cname) {
     var name = cname + "=";
     var ca = document.cookie.split(';');
-    for(var i = 0; i <ca.length; i++) {
+    for (var i = 0; i < ca.length; i++) {
         var c = ca[i];
-        while (c.charAt(0)==' ') {
+        while (c.charAt(0) == ' ') {
             c = c.substring(1);
         }
         if (c.indexOf(name) == 0) {
-            return c.substring(name.length,c.length);
+            return c.substring(name.length, c.length);
         }
     }
     return "";
 }
 
 function eraseCookie(name) {
-    createCookie(name,"",-1);
+    createCookie(name, "", -1);
 }
 
-function apigee_date_range(){
+function apigee_date_range() {
     var start = new Date();
     var yyyy = start.getFullYear();
     var mm = start.getMonth();
     var dd = start.getDate();
-    var past = mm+'/'+dd+'/'+yyyy;
-    
+    var past = mm + '/' + dd + '/' + yyyy;
+
     var end = new Date();
     var yyyy = end.getFullYear();
-    var mm = end.getMonth()+1;
+    var mm = end.getMonth() + 1;
     var dd = end.getDate();
-    var current = mm+'/'+dd+'/'+yyyy;
+    var current = mm + '/' + dd + '/' + yyyy;
 
-    var timestring = "?select=avg(total_response_time)&timeRange="+past+"%2000:00~"+current+"%2000:00&timeUnit=day";
+    var timestring = "?select=avg(total_response_time)&timeRange=" + past + "%2000:00~" + current + "%2000:00&timeUnit=day";
     return timestring;
 }
 
 $(function() {
-  $('#swaggerhub').on("submit",function(e) {
-    e.preventDefault();
-    createCookie("swaggercookie_url",document.getElementById("url").value,30);
-    createCookie("swaggercookie_key",document.getElementById("key").value,30);
-    $("#submit").remove()
-    $("#swaggerhub").append('<div class="alert alert-info"><strong>Updated!</strong></div>');
-  });
+    $('#swaggerhub').on("submit", function(e) {
+        e.preventDefault();
+        createCookie("swaggercookie_url", document.getElementById("url").value, 30);
+        createCookie("swaggercookie_key", document.getElementById("key").value, 30);
+        $("#submit").remove()
+        $("#swaggerhub").append('<div class="alert alert-info"><strong>Updated!</strong></div>');
+    });
 });
 
 $(function() {
-  $('#apigee').on("submit",function(e) {
-    e.preventDefault();
-    createCookie("apigee_key",document.getElementById("base64").value,30);
-    var dateTime = apigee_date_range();
-    createCookie("apigee_url",document.getElementById("target").value+dateTime,30);
-    $("#submit").remove()
-    $("#apigee").append('<div class="alert alert-info"><strong>Updated!</strong></div>');
-  });
+    $('#apigee').on("submit", function(e) {
+        e.preventDefault();
+        createCookie("apigee_key", document.getElementById("base64").value, 30);
+        var dateTime = apigee_date_range();
+        createCookie("apigee_url", document.getElementById("target").value + dateTime, 30);
+        $("#submit").remove()
+        $("#apigee").append('<div class="alert alert-info"><strong>Updated!</strong></div>');
+    });
 });
 
 $(function() {
-  $('#clear').on("click", function(e) {
-   eraseCookie("swaggercookie_url");
-   eraseCookie("swaggercookie_key");
-   eraseCookie("apigee_key");
-   eraseCookie("apigee_url");
-   location.reload();
-  });
+    $('#clear').on("click", function(e) {
+        eraseCookie("swaggercookie_url");
+        eraseCookie("swaggercookie_key");
+        eraseCookie("apigee_key");
+        eraseCookie("apigee_url");
+        location.reload();
+    });
 });

--- a/dist/lib/cookies.js
+++ b/dist/lib/cookies.js
@@ -27,6 +27,23 @@ function eraseCookie(name) {
     createCookie(name,"",-1);
 }
 
+function apigee_date_range(){
+    var start = new Date();
+    var yyyy = start.getFullYear();
+    var mm = start.getMonth();
+    var dd = start.getDate();
+    var past = mm+'/'+dd+'/'+yyyy;
+    
+    var end = new Date();
+    var yyyy = end.getFullYear();
+    var mm = end.getMonth()+1;
+    var dd = end.getDate();
+    var current = mm+'/'+dd+'/'+yyyy;
+
+    var timestring = "?select=avg(total_response_time)&timeRange="+past+"%2000:00~"+current+"%2000:00&timeUnit=day";
+    return timestring;
+}
+
 $(function() {
   $('#swaggerhub').on("submit",function(e) {
     e.preventDefault();
@@ -41,7 +58,8 @@ $(function() {
   $('#apigee').on("submit",function(e) {
     e.preventDefault();
     createCookie("apigee_key",document.getElementById("base64").value,30);
-    createCookie("apigee_url",document.getElementById("target").value,30);
+    var dateTime = apigee_date_range();
+    createCookie("apigee_url",document.getElementById("target").value+dateTime,30);
     $("#submit").remove()
     $("#apigee").append('<div class="alert alert-info"><strong>Updated!</strong></div>');
   });
@@ -49,9 +67,10 @@ $(function() {
 
 $(function() {
   $('#clear').on("click", function(e) {
-   e.preventDefault();
    eraseCookie("swaggercookie_url");
    eraseCookie("swaggercookie_key");
    eraseCookie("apigee_key");
+   eraseCookie("apigee_url");
+   location.reload();
   });
 });

--- a/dist/lib/cors.js
+++ b/dist/lib/cors.js
@@ -16,7 +16,7 @@ function createCORSRequest(method, url) {
 }
 
 // Make the actual CORS request.
-function makeCorsRequest(url, key, callback) {
+function makeCorsRequest(url, key, method, callback) {
     var xhr = createCORSRequest('GET', url);
     if (!xhr) {
         console.log('CORS not supported');
@@ -29,18 +29,20 @@ function makeCorsRequest(url, key, callback) {
         try {
             var text = JSON.parse(xhr.responseText);
         } catch (e) {
-            $.ajax({
-                url: "api/create.php",
-                global: "false",
-                type: "POST",
-                cache: "false",
-                data: {
-                    "data": xhr.responseText
-                },
-                success: function(response) {
-                    callback(response);
-                }
-            });
+	    if (method == "swaggerhub"){
+          	  $.ajax({
+                	url: "api/create.php",
+                	global: "false",
+                	type: "POST",
+                	cache: "false",
+                	data: {
+                    	"data": xhr.responseText
+                	},
+                	success: function(response) {
+                    		callback(response);
+               		}
+            	 });
+	    }
         }
         callback(text);
     };

--- a/dist/lib/cors.js
+++ b/dist/lib/cors.js
@@ -29,20 +29,20 @@ function makeCorsRequest(url, key, method, callback) {
         try {
             var text = JSON.parse(xhr.responseText);
         } catch (e) {
-	    if (method == "swaggerhub"){
-          	  $.ajax({
-                	url: "api/create.php",
-                	global: "false",
-                	type: "POST",
-                	cache: "false",
-                	data: {
-                    	"data": xhr.responseText
-                	},
-                	success: function(response) {
-                    		callback(response);
-               		}
-            	 });
-	    }
+            if (method == "swaggerhub") {
+                $.ajax({
+                    url: "api/create.php",
+                    global: "false",
+                    type: "POST",
+                    cache: "false",
+                    data: {
+                        "data": xhr.responseText
+                    },
+                    success: function(response) {
+                        callback(response);
+                    }
+                });
+            }
         }
         callback(text);
     };

--- a/dist/lib/gen-swagger.js
+++ b/dist/lib/gen-swagger.js
@@ -29,7 +29,22 @@ function gen_swagger(target_url) {
         });
         window.swaggerUi.load();
     }
+	$("#options-menu").empty();
+	$("#options-menu").append('<div class = "btn-group"><button type = "button" data = "" id = "overview" class = "btn btn-default">Overview</button><button type = "button" data = "" id = "performance" class = "btn btn-default">Performance</button><button type = "button" id = "feedback" data = "" class = "btn btn-default">Feedback</button></div>');
+	$("#performance").on("click", function(){
+		collect_metrics($(this).attr("data"));
+	});
+	$("#overview").on("click", function(){
+		gen_swagger($(this).attr("data"));
+	});
 }
+
+$('#swagger-ui-container').bind('DOMSubtreeModified', function(){
+		$('#performance').attr("data",window.swaggerUi.api['host']);
+		$('#overview').attr("data",window.swaggerUi.api['url']);
+});
+
+
 
 function gen_swaggerhub(target_id) {
     data = JSON.parse(target_id);
@@ -45,6 +60,7 @@ function gen_swaggerhub(target_id) {
                 onComplete: function(swaggerApi, swaggerUi) {
                     if (window.SwaggerTranslator) {
                         window.SwaggerTranslator.translate();
+
                     }
                 },
                 onFailure: function(data) {
@@ -77,6 +93,9 @@ $(document).ready(function() {
         } else {
             $("#listprime").find("div").slideDown();
         }
+    });
+    $('#options-menu .btn-group').click(function() {
+    	alert("Something was clicked"); // test - not working
     });
     $.ajax({
         data: {

--- a/dist/lib/gen-swagger.js
+++ b/dist/lib/gen-swagger.js
@@ -57,6 +57,16 @@ function toggler(divId) {
     $("#" + divId).toggle();
 }
 
+function getParameterByName(name, url) {
+    if (!url) url = window.location.href;
+    name = name.replace(/[\[\]]/g, "\\$&");
+    var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+        results = regex.exec(url);
+    if (!results) return null;
+    if (!results[2]) return '';
+    return decodeURIComponent(results[2].replace(/\+/g, " "));
+}
+
 function gen_swaggerhub(target_id) {
     data = JSON.parse(target_id);
     target = data["properties"][0]["url"] + "/swagger.yaml";
@@ -94,11 +104,59 @@ function add_window(form_name) {
     document.getElementById(form_name.concat("_form")).className = "visible";
 }
 
+// Code attributed to Stack Overflow user Adil Malik
+// https://stackoverflow.com/questions/1090948/change-url-parameters/10997390#10997390
+
+function updateURLParameter(url, param, paramVal)
+{
+    var TheAnchor = null;
+    var newAdditionalURL = "";
+    var tempArray = url.split("?");
+    var baseURL = tempArray[0];
+    var additionalURL = tempArray[1];
+    var temp = "";
+
+    if (additionalURL) 
+    {
+        var tmpAnchor = additionalURL.split("#");
+        var TheParams = tmpAnchor[0];
+            TheAnchor = tmpAnchor[1];
+        if(TheAnchor)
+            additionalURL = TheParams;
+
+        tempArray = additionalURL.split("&");
+
+        for (i=0; i<tempArray.length; i++)
+        {
+            if(tempArray[i].split('=')[0] != param)
+            {
+                newAdditionalURL += temp + tempArray[i];
+                temp = "&";
+            }
+        }        
+    }
+    else
+    {
+        var tmpAnchor = baseURL.split("#");
+        var TheParams = tmpAnchor[0];
+            TheAnchor  = tmpAnchor[1];
+
+        if(TheParams)
+            baseURL = TheParams;
+    }
+
+    if(TheAnchor)
+        paramVal += "#" + TheAnchor;
+
+    var rows_txt = temp + "" + param + "=" + paramVal;
+    return baseURL + "?" + newAdditionalURL + rows_txt;
+}
+
 $(document).ready(function() {
+    var target_API = getParameterByName('api');
     $("#search").keyup(function() {
         var filter = $(this).val(); // get the value of the input, which we filter on
         if (filter) {
-            console.log(filter);
             $("#listprime div").find("div:not(:contains(" + filter + "))").slideUp("fast");
             $("#listprime div").find("div:contains(" + filter + ")").slideDown("fast");
         } else {
@@ -130,7 +188,6 @@ $(document).ready(function() {
         $("li").removeClass("active");
         $("div").removeClass("active");
     });
-
     $.ajax({
         data: {
             'cmd': 'group'
@@ -146,12 +203,17 @@ $(document).ready(function() {
 
             });
             $("ul#listprime div div").on("click", function() {
+    		var newURL = updateURLParameter(window.location.href, 'api', ($(this).text()));
+    		window.history.replaceState( {} , 'title', newURL );
                 gen_swagger(($(this).attr('id')));
                 $("li").removeClass("active");
                 $("div").removeClass("active");
                 $(this).addClass("active");
             });
 
+    	    if (target_API != null){
+	        $('ul#listprime div div:contains("'+target_API+'")').trigger("click");
+            }
         }
     });
 

--- a/dist/lib/gen-swagger.js
+++ b/dist/lib/gen-swagger.js
@@ -70,7 +70,7 @@ function getParameterByName(name, url) {
 function gen_swaggerhub(target_id) {
     data = JSON.parse(target_id);
     target = data["properties"][0]["url"] + "/swagger.yaml";
-    makeCorsRequest(target, getCookie("swaggercookie_key"), function(val) {
+    makeCorsRequest(target, getCookie("swaggercookie_key"), "swaggerhub", function(val) {
         if (typeof val != "undefined") {
             val = "/api/" + val;
             window.swaggerUi = new SwaggerUi({

--- a/dist/lib/gen-swagger.js
+++ b/dist/lib/gen-swagger.js
@@ -30,13 +30,22 @@ function gen_swagger(target_url) {
         window.swaggerUi.load();
     }
 	$("#options-menu").empty();
-	$("#options-menu").append('<div class = "btn-group"><button type = "button" data = "" id = "overview" class = "btn btn-default">Overview</button><button type = "button" data = "" id = "performance" class = "btn btn-default">Performance</button><button type = "button" id = "feedback" data = "" class = "btn btn-default">Feedback</button></div>');
+	$("#options-menu").append('<div class = "btn-group"><button type = "button" data = "" id = "overview" class = "btn btn-default active">Overview</button><button type = "button" data = "" id = "performance" class = "btn btn-default">Performance</button><button type = "button" id = "feedback" data = "" class = "btn btn-default">Feedback</button></div>');
 	$("#performance").on("click", function(){
 		collect_metrics($(this).attr("data"));
+                $("#overview").removeClass("active");
+                $("#feedback").removeClass("active");
 	});
 	$("#overview").on("click", function(){
+                $("#feedback").removeClass("active");
+                $("#performance").removeClass("active");
 		gen_swagger($(this).attr("data"));
 	});
+	$("#feedback").on("click", function(){
+                $("#overview").removeClass("active");
+                $("#performance").removeClass("active");
+	});
+	
 }
 
 $('#swagger-ui-container').bind('DOMSubtreeModified', function(){
@@ -44,7 +53,9 @@ $('#swagger-ui-container').bind('DOMSubtreeModified', function(){
 		$('#overview').attr("data",window.swaggerUi.api['url']);
 });
 
-
+function toggler(divId) {
+    $("#" + divId).toggle();
+}
 
 function gen_swaggerhub(target_id) {
     data = JSON.parse(target_id);

--- a/dist/lib/gen-swagger.js
+++ b/dist/lib/gen-swagger.js
@@ -29,28 +29,28 @@ function gen_swagger(target_url) {
         });
         window.swaggerUi.load();
     }
-	$("#options-menu").empty();
-	$("#options-menu").append('<div class = "btn-group"><button type = "button" data = "" id = "overview" class = "btn btn-default active">Overview</button><button type = "button" data = "" id = "performance" class = "btn btn-default">Performance</button><button type = "button" id = "feedback" data = "" class = "btn btn-default">Feedback</button></div>');
-	$("#performance").on("click", function(){
-		collect_metrics($(this).attr("data"));
-                $("#overview").removeClass("active");
-                $("#feedback").removeClass("active");
-	});
-	$("#overview").on("click", function(){
-                $("#feedback").removeClass("active");
-                $("#performance").removeClass("active");
-		gen_swagger($(this).attr("data"));
-	});
-	$("#feedback").on("click", function(){
-                $("#overview").removeClass("active");
-                $("#performance").removeClass("active");
-	});
-	
+    $("#options-menu").empty();
+    $("#options-menu").append('<div class = "btn-group"><button type = "button" data = "" id = "overview" class = "btn btn-default active">Overview</button><button type = "button" data = "" id = "performance" class = "btn btn-default">Performance</button><button type = "button" id = "feedback" data = "" class = "btn btn-default">Feedback</button></div>');
+    $("#performance").on("click", function() {
+        collect_metrics($(this).attr("data"));
+        $("#overview").removeClass("active");
+        $("#feedback").removeClass("active");
+    });
+    $("#overview").on("click", function() {
+        $("#feedback").removeClass("active");
+        $("#performance").removeClass("active");
+        gen_swagger($(this).attr("data"));
+    });
+    $("#feedback").on("click", function() {
+        $("#overview").removeClass("active");
+        $("#performance").removeClass("active");
+    });
+
 }
 
-$('#swagger-ui-container').bind('DOMSubtreeModified', function(){
-		$('#performance').attr("data",window.swaggerUi.api['host']);
-		$('#overview').attr("data",window.swaggerUi.api['url']);
+$('#swagger-ui-container').bind('DOMSubtreeModified', function() {
+    $('#performance').attr("data", window.swaggerUi.api['host']);
+    $('#overview').attr("data", window.swaggerUi.api['url']);
 });
 
 function toggler(divId) {
@@ -107,8 +107,7 @@ function add_window(form_name) {
 // Code attributed to Stack Overflow user Adil Malik
 // https://stackoverflow.com/questions/1090948/change-url-parameters/10997390#10997390
 
-function updateURLParameter(url, param, paramVal)
-{
+function updateURLParameter(url, param, paramVal) {
     var TheAnchor = null;
     var newAdditionalURL = "";
     var tempArray = url.split("?");
@@ -116,36 +115,31 @@ function updateURLParameter(url, param, paramVal)
     var additionalURL = tempArray[1];
     var temp = "";
 
-    if (additionalURL) 
-    {
+    if (additionalURL) {
         var tmpAnchor = additionalURL.split("#");
         var TheParams = tmpAnchor[0];
-            TheAnchor = tmpAnchor[1];
-        if(TheAnchor)
+        TheAnchor = tmpAnchor[1];
+        if (TheAnchor)
             additionalURL = TheParams;
 
         tempArray = additionalURL.split("&");
 
-        for (i=0; i<tempArray.length; i++)
-        {
-            if(tempArray[i].split('=')[0] != param)
-            {
+        for (i = 0; i < tempArray.length; i++) {
+            if (tempArray[i].split('=')[0] != param) {
                 newAdditionalURL += temp + tempArray[i];
                 temp = "&";
             }
-        }        
-    }
-    else
-    {
+        }
+    } else {
         var tmpAnchor = baseURL.split("#");
         var TheParams = tmpAnchor[0];
-            TheAnchor  = tmpAnchor[1];
+        TheAnchor = tmpAnchor[1];
 
-        if(TheParams)
+        if (TheParams)
             baseURL = TheParams;
     }
 
-    if(TheAnchor)
+    if (TheAnchor)
         paramVal += "#" + TheAnchor;
 
     var rows_txt = temp + "" + param + "=" + paramVal;
@@ -164,7 +158,7 @@ $(document).ready(function() {
         }
     });
     $('#options-menu .btn-group').click(function() {
-    	alert("Something was clicked"); // test - not working
+        alert("Something was clicked"); // test - not working
     });
     $.ajax({
         data: {
@@ -203,16 +197,16 @@ $(document).ready(function() {
 
             });
             $("ul#listprime div div").on("click", function() {
-    		var newURL = updateURLParameter(window.location.href, 'api', ($(this).text()));
-    		window.history.replaceState( {} , 'title', newURL );
+                var newURL = updateURLParameter(window.location.href, 'api', ($(this).text()));
+                window.history.replaceState({}, 'title', newURL);
                 gen_swagger(($(this).attr('id')));
                 $("li").removeClass("active");
                 $("div").removeClass("active");
                 $(this).addClass("active");
             });
 
-    	    if (target_API != null){
-	        $('ul#listprime div div:contains("'+target_API+'")').trigger("click");
+            if (target_API != null) {
+                $('ul#listprime div div:contains("' + target_API + '")').trigger("click");
             }
         }
     });

--- a/dist/lib/jquery.flot.axislabels.js
+++ b/dist/lib/jquery.flot.axislabels.js
@@ -1,0 +1,466 @@
+/*
+Axis Labels Plugin for flot.
+http://github.com/markrcote/flot-axislabels
+
+Original code is Copyright (c) 2010 Xuan Luo.
+Original code was released under the GPLv3 license by Xuan Luo, September 2010.
+Original code was rereleased under the MIT license by Xuan Luo, April 2012.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+(function ($) {
+    var options = {
+      axisLabels: {
+        show: true
+      }
+    };
+
+    function canvasSupported() {
+        return !!document.createElement('canvas').getContext;
+    }
+
+    function canvasTextSupported() {
+        if (!canvasSupported()) {
+            return false;
+        }
+        var dummy_canvas = document.createElement('canvas');
+        var context = dummy_canvas.getContext('2d');
+        return typeof context.fillText == 'function';
+    }
+
+    function css3TransitionSupported() {
+        var div = document.createElement('div');
+        return typeof div.style.MozTransition != 'undefined'    // Gecko
+            || typeof div.style.OTransition != 'undefined'      // Opera
+            || typeof div.style.webkitTransition != 'undefined' // WebKit
+            || typeof div.style.transition != 'undefined';
+    }
+
+
+    function AxisLabel(axisName, position, padding, plot, opts) {
+        this.axisName = axisName;
+        this.position = position;
+        this.padding = padding;
+        this.plot = plot;
+        this.opts = opts;
+        this.width = 0;
+        this.height = 0;
+    }
+
+    AxisLabel.prototype.cleanup = function() {
+    };
+
+
+    CanvasAxisLabel.prototype = new AxisLabel();
+    CanvasAxisLabel.prototype.constructor = CanvasAxisLabel;
+    function CanvasAxisLabel(axisName, position, padding, plot, opts) {
+        AxisLabel.prototype.constructor.call(this, axisName, position, padding,
+                                             plot, opts);
+    }
+
+    CanvasAxisLabel.prototype.calculateSize = function() {
+        if (!this.opts.axisLabelFontSizePixels)
+            this.opts.axisLabelFontSizePixels = 14;
+        if (!this.opts.axisLabelFontFamily)
+            this.opts.axisLabelFontFamily = 'sans-serif';
+
+        var textWidth = this.opts.axisLabelFontSizePixels + this.padding;
+        var textHeight = this.opts.axisLabelFontSizePixels + this.padding;
+        if (this.position == 'left' || this.position == 'right') {
+            this.width = this.opts.axisLabelFontSizePixels + this.padding;
+            this.height = 0;
+        } else {
+            this.width = 0;
+            this.height = this.opts.axisLabelFontSizePixels + this.padding;
+        }
+    };
+
+    CanvasAxisLabel.prototype.draw = function(box) {
+        if (!this.opts.axisLabelColour)
+            this.opts.axisLabelColour = 'black';
+        var ctx = this.plot.getCanvas().getContext('2d');
+        ctx.save();
+        ctx.font = this.opts.axisLabelFontSizePixels + 'px ' +
+            this.opts.axisLabelFontFamily;
+        ctx.fillStyle = this.opts.axisLabelColour;
+        var width = ctx.measureText(this.opts.axisLabel).width;
+        var height = this.opts.axisLabelFontSizePixels;
+        var x, y, angle = 0;
+        if (this.position == 'top') {
+            x = box.left + box.width/2 - width/2;
+            y = box.top + height*0.72;
+        } else if (this.position == 'bottom') {
+            x = box.left + box.width/2 - width/2;
+            y = box.top + box.height - height*0.72;
+        } else if (this.position == 'left') {
+            x = box.left + height*0.72;
+            y = box.height/2 + box.top + width/2;
+            angle = -Math.PI/2;
+        } else if (this.position == 'right') {
+            x = box.left + box.width - height*0.72;
+            y = box.height/2 + box.top - width/2;
+            angle = Math.PI/2;
+        }
+        ctx.translate(x, y);
+        ctx.rotate(angle);
+        ctx.fillText(this.opts.axisLabel, 0, 0);
+        ctx.restore();
+    };
+
+
+    HtmlAxisLabel.prototype = new AxisLabel();
+    HtmlAxisLabel.prototype.constructor = HtmlAxisLabel;
+    function HtmlAxisLabel(axisName, position, padding, plot, opts) {
+        AxisLabel.prototype.constructor.call(this, axisName, position,
+                                             padding, plot, opts);
+        this.elem = null;
+    }
+
+    HtmlAxisLabel.prototype.calculateSize = function() {
+        var elem = $('<div class="axisLabels" style="position:absolute;">' +
+                     this.opts.axisLabel + '</div>');
+        this.plot.getPlaceholder().append(elem);
+        // store height and width of label itself, for use in draw()
+        this.labelWidth = elem.outerWidth(true);
+        this.labelHeight = elem.outerHeight(true);
+        elem.remove();
+
+        this.width = this.height = 0;
+        if (this.position == 'left' || this.position == 'right') {
+            this.width = this.labelWidth + this.padding;
+        } else {
+            this.height = this.labelHeight + this.padding;
+        }
+    };
+
+    HtmlAxisLabel.prototype.cleanup = function() {
+        if (this.elem) {
+            this.elem.remove();
+        }
+    };
+
+    HtmlAxisLabel.prototype.draw = function(box) {
+        this.plot.getPlaceholder().find('#' + this.axisName + 'Label').remove();
+        this.elem = $('<div id="' + this.axisName +
+                      'Label" " class="axisLabels" style="position:absolute;">'
+                      + this.opts.axisLabel + '</div>');
+        this.plot.getPlaceholder().append(this.elem);
+        if (this.position == 'top') {
+            this.elem.css('left', box.left + box.width/2 - this.labelWidth/2 +
+                          'px');
+            this.elem.css('top', box.top + 'px');
+        } else if (this.position == 'bottom') {
+            this.elem.css('left', box.left + box.width/2 - this.labelWidth/2 +
+                          'px');
+            this.elem.css('top', box.top + box.height - this.labelHeight +
+                          'px');
+        } else if (this.position == 'left') {
+            this.elem.css('top', box.top + box.height/2 - this.labelHeight/2 +
+                          'px');
+            this.elem.css('left', box.left + 'px');
+        } else if (this.position == 'right') {
+            this.elem.css('top', box.top + box.height/2 - this.labelHeight/2 +
+                          'px');
+            this.elem.css('left', box.left + box.width - this.labelWidth +
+                          'px');
+        }
+    };
+
+
+    CssTransformAxisLabel.prototype = new HtmlAxisLabel();
+    CssTransformAxisLabel.prototype.constructor = CssTransformAxisLabel;
+    function CssTransformAxisLabel(axisName, position, padding, plot, opts) {
+        HtmlAxisLabel.prototype.constructor.call(this, axisName, position,
+                                                 padding, plot, opts);
+    }
+
+    CssTransformAxisLabel.prototype.calculateSize = function() {
+        HtmlAxisLabel.prototype.calculateSize.call(this);
+        this.width = this.height = 0;
+        if (this.position == 'left' || this.position == 'right') {
+            this.width = this.labelHeight + this.padding;
+        } else {
+            this.height = this.labelHeight + this.padding;
+        }
+    };
+
+    CssTransformAxisLabel.prototype.transforms = function(degrees, x, y) {
+        var stransforms = {
+            '-moz-transform': '',
+            '-webkit-transform': '',
+            '-o-transform': '',
+            '-ms-transform': ''
+        };
+        if (x != 0 || y != 0) {
+            var stdTranslate = ' translate(' + x + 'px, ' + y + 'px)';
+            stransforms['-moz-transform'] += stdTranslate;
+            stransforms['-webkit-transform'] += stdTranslate;
+            stransforms['-o-transform'] += stdTranslate;
+            stransforms['-ms-transform'] += stdTranslate;
+        }
+        if (degrees != 0) {
+            var rotation = degrees / 90;
+            var stdRotate = ' rotate(' + degrees + 'deg)';
+            stransforms['-moz-transform'] += stdRotate;
+            stransforms['-webkit-transform'] += stdRotate;
+            stransforms['-o-transform'] += stdRotate;
+            stransforms['-ms-transform'] += stdRotate;
+        }
+        var s = 'top: 0; left: 0; ';
+        for (var prop in stransforms) {
+            if (stransforms[prop]) {
+                s += prop + ':' + stransforms[prop] + ';';
+            }
+        }
+        s += ';';
+        return s;
+    };
+
+    CssTransformAxisLabel.prototype.calculateOffsets = function(box) {
+        var offsets = { x: 0, y: 0, degrees: 0 };
+        if (this.position == 'bottom') {
+            offsets.x = box.left + box.width/2 - this.labelWidth/2;
+            offsets.y = box.top + box.height - this.labelHeight;
+        } else if (this.position == 'top') {
+            offsets.x = box.left + box.width/2 - this.labelWidth/2;
+            offsets.y = box.top;
+        } else if (this.position == 'left') {
+            offsets.degrees = -90;
+            offsets.x = box.left - this.labelWidth/2 + this.labelHeight/2;
+            offsets.y = box.height/2 + box.top;
+        } else if (this.position == 'right') {
+            offsets.degrees = 90;
+            offsets.x = box.left + box.width - this.labelWidth/2
+                        - this.labelHeight/2;
+            offsets.y = box.height/2 + box.top;
+        }
+        offsets.x = Math.round(offsets.x);
+        offsets.y = Math.round(offsets.y);
+
+        return offsets;
+    };
+
+    CssTransformAxisLabel.prototype.draw = function(box) {
+        this.plot.getPlaceholder().find("." + this.axisName + "Label").remove();
+        var offsets = this.calculateOffsets(box);
+        this.elem = $('<div class="axisLabels ' + this.axisName +
+                      'Label" style="position:absolute; ' +
+                      this.transforms(offsets.degrees, offsets.x, offsets.y) +
+                      '">' + this.opts.axisLabel + '</div>');
+        this.plot.getPlaceholder().append(this.elem);
+    };
+
+
+    IeTransformAxisLabel.prototype = new CssTransformAxisLabel();
+    IeTransformAxisLabel.prototype.constructor = IeTransformAxisLabel;
+    function IeTransformAxisLabel(axisName, position, padding, plot, opts) {
+        CssTransformAxisLabel.prototype.constructor.call(this, axisName,
+                                                         position, padding,
+                                                         plot, opts);
+        this.requiresResize = false;
+    }
+
+    IeTransformAxisLabel.prototype.transforms = function(degrees, x, y) {
+        // I didn't feel like learning the crazy Matrix stuff, so this uses
+        // a combination of the rotation transform and CSS positioning.
+        var s = '';
+        if (degrees != 0) {
+            var rotation = degrees/90;
+            while (rotation < 0) {
+                rotation += 4;
+            }
+            s += ' filter: progid:DXImageTransform.Microsoft.BasicImage(rotation=' + rotation + '); ';
+            // see below
+            this.requiresResize = (this.position == 'right');
+        }
+        if (x != 0) {
+            s += 'left: ' + x + 'px; ';
+        }
+        if (y != 0) {
+            s += 'top: ' + y + 'px; ';
+        }
+        return s;
+    };
+
+    IeTransformAxisLabel.prototype.calculateOffsets = function(box) {
+        var offsets = CssTransformAxisLabel.prototype.calculateOffsets.call(
+                          this, box);
+        // adjust some values to take into account differences between
+        // CSS and IE rotations.
+        if (this.position == 'top') {
+            // FIXME: not sure why, but placing this exactly at the top causes
+            // the top axis label to flip to the bottom...
+            offsets.y = box.top + 1;
+        } else if (this.position == 'left') {
+            offsets.x = box.left;
+            offsets.y = box.height/2 + box.top - this.labelWidth/2;
+        } else if (this.position == 'right') {
+            offsets.x = box.left + box.width - this.labelHeight;
+            offsets.y = box.height/2 + box.top - this.labelWidth/2;
+        }
+        return offsets;
+    };
+
+    IeTransformAxisLabel.prototype.draw = function(box) {
+        CssTransformAxisLabel.prototype.draw.call(this, box);
+        if (this.requiresResize) {
+            this.elem = this.plot.getPlaceholder().find("." + this.axisName +
+                                                        "Label");
+            // Since we used CSS positioning instead of transforms for
+            // translating the element, and since the positioning is done
+            // before any rotations, we have to reset the width and height
+            // in case the browser wrapped the text (specifically for the
+            // y2axis).
+            this.elem.css('width', this.labelWidth);
+            this.elem.css('height', this.labelHeight);
+        }
+    };
+
+
+    function init(plot) {
+        plot.hooks.processOptions.push(function (plot, options) {
+
+            if (!options.axisLabels.show)
+                return;
+
+            // This is kind of a hack. There are no hooks in Flot between
+            // the creation and measuring of the ticks (setTicks, measureTickLabels
+            // in setupGrid() ) and the drawing of the ticks and plot box
+            // (insertAxisLabels in setupGrid() ).
+            //
+            // Therefore, we use a trick where we run the draw routine twice:
+            // the first time to get the tick measurements, so that we can change
+            // them, and then have it draw it again.
+            var secondPass = false;
+
+            var axisLabels = {};
+            var axisOffsetCounts = { left: 0, right: 0, top: 0, bottom: 0 };
+
+            var defaultPadding = 2;  // padding between axis and tick labels
+            plot.hooks.draw.push(function (plot, ctx) {
+                var hasAxisLabels = false;
+                if (!secondPass) {
+                    // MEASURE AND SET OPTIONS
+                    $.each(plot.getAxes(), function(axisName, axis) {
+                        var opts = axis.options // Flot 0.7
+                            || plot.getOptions()[axisName]; // Flot 0.6
+
+                        // Handle redraws initiated outside of this plug-in.
+                        if (axisName in axisLabels) {
+                            axis.labelHeight = axis.labelHeight -
+                                axisLabels[axisName].height;
+                            axis.labelWidth = axis.labelWidth -
+                                axisLabels[axisName].width;
+                            opts.labelHeight = axis.labelHeight;
+                            opts.labelWidth = axis.labelWidth;
+                            axisLabels[axisName].cleanup();
+                            delete axisLabels[axisName];
+                        }
+
+                        if (!opts || !opts.axisLabel || !axis.show)
+                            return;
+
+                        hasAxisLabels = true;
+                        var renderer = null;
+
+                        if (!opts.axisLabelUseHtml &&
+                            navigator.appName == 'Microsoft Internet Explorer') {
+                            var ua = navigator.userAgent;
+                            var re  = new RegExp("MSIE ([0-9]{1,}[\.0-9]{0,})");
+                            if (re.exec(ua) != null) {
+                                rv = parseFloat(RegExp.$1);
+                            }
+                            if (rv >= 9 && !opts.axisLabelUseCanvas && !opts.axisLabelUseHtml) {
+                                renderer = CssTransformAxisLabel;
+                            } else if (!opts.axisLabelUseCanvas && !opts.axisLabelUseHtml) {
+                                renderer = IeTransformAxisLabel;
+                            } else if (opts.axisLabelUseCanvas) {
+                                renderer = CanvasAxisLabel;
+                            } else {
+                                renderer = HtmlAxisLabel;
+                            }
+                        } else {
+                            if (opts.axisLabelUseHtml || (!css3TransitionSupported() && !canvasTextSupported()) && !opts.axisLabelUseCanvas) {
+                                renderer = HtmlAxisLabel;
+                            } else if (opts.axisLabelUseCanvas || !css3TransitionSupported()) {
+                                renderer = CanvasAxisLabel;
+                            } else {
+                                renderer = CssTransformAxisLabel;
+                            }
+                        }
+
+                        var padding = opts.axisLabelPadding === undefined ?
+                                      defaultPadding : opts.axisLabelPadding;
+
+                        axisLabels[axisName] = new renderer(axisName,
+                                                            axis.position, padding,
+                                                            plot, opts);
+
+                        // flot interprets axis.labelHeight and .labelWidth as
+                        // the height and width of the tick labels. We increase
+                        // these values to make room for the axis label and
+                        // padding.
+
+                        axisLabels[axisName].calculateSize();
+
+                        // AxisLabel.height and .width are the size of the
+                        // axis label and padding.
+                        // Just set opts here because axis will be sorted out on
+                        // the redraw.
+
+                        opts.labelHeight = axis.labelHeight +
+                            axisLabels[axisName].height;
+                        opts.labelWidth = axis.labelWidth +
+                            axisLabels[axisName].width;
+                    });
+
+                    // If there are axis labels, re-draw with new label widths and
+                    // heights.
+
+                    if (hasAxisLabels) {
+                        secondPass = true;
+                        plot.setupGrid();
+                        plot.draw();
+                    }
+                } else {
+                    secondPass = false;
+                    // DRAW
+                    $.each(plot.getAxes(), function(axisName, axis) {
+                        var opts = axis.options // Flot 0.7
+                            || plot.getOptions()[axisName]; // Flot 0.6
+                        if (!opts || !opts.axisLabel || !axis.show)
+                            return;
+
+                        axisLabels[axisName].draw(axis.box);
+                    });
+                }
+            });
+        });
+    }
+
+
+    $.plot.plugins.push({
+        init: init,
+        options: options,
+        name: 'axisLabels',
+        version: '2.0'
+    });
+})(jQuery);

--- a/dist/lib/swagger-ui.js
+++ b/dist/lib/swagger-ui.js
@@ -20036,10 +20036,10 @@ SwaggerUi.Views.MainView = Backbone.View.extend({
     } else {
       // Default validator
       if(window.location.protocol === 'https:') {
-        this.model.validatorUrl = 'https://online.swagger.io/validator';
+        this.model.validatorUrl = null;
       }
       else {
-        this.model.validatorUrl = 'http://online.swagger.io/validator';
+        this.model.validatorUrl = null;
       }
     }
 

--- a/dist/options.php
+++ b/dist/options.php
@@ -1,16 +1,35 @@
 <?php include "header.htm"?>
-<script src="lib/cookies.js"></script> 
 <div class="container">
 <h3>SwaggerHub Configuration</h3>
 <p>Current saved data:</p>
-<ul id="info">
+<table class="table table-hover">
+     <tbody>
+       <tr id="swaggerhub_table">
+       </tr>
+       <tr id="apigee_table">
+       </tr>
+     </tbody>
+   </table>
 <script>
-$("#info").append('<li> URL: ' + getCookie("swaggercookie_url") + '</li>');
-$("#info").append('<li> Key : ' + getCookie("swaggercookie_key") + '</li>');
-</script>
-</ul>
-<form id="swaggerhub">
-<h4>Update SwaggerHub Information:</h4>
+$("#info").append('<td> URL: ' + getCookie("swaggercookie_url") + '</td>');
+$("#info").append('<td> Key : ' + getCookie("swaggercookie_key") + '</td>');
+$("#swaggerhub_table").append('<td> URL: ' + getCookie("swaggercookie_url") + '</td>');
+if(getCookie("swaggercookie_key")) {
+       $("#swaggerhub_table").append('<td>Swaggerhub key is set</td>');
+}else{
+       $("#swaggerhub_table").append('<td>Swaggerhub key is not set</td>');
+}
+$("#apigee_table").append('<td> URL: ' + getCookie("apigee_url") + '</td>');
+if(getCookie("apigee_key")) {
+       $("#apigee_table").append('<td>Apigee data is set</td>');
+}else{
+       $("#apigee_table").append('<td>Apigee data is not set</td>');
+}
+ </script>
+ 
+
+<button type="button" class="btn btn-primary btn-lg" onclick="toggler('swaggerhub')">Update Swaggerhub Information</button>
+<form id="swaggerhub" style="display:none">
 <div class="form-group row">
   <label for="example-url-input" class="col-xs-2 col-form-label">URL</label>
   <div class="col-xs-10">
@@ -24,7 +43,25 @@ $("#info").append('<li> Key : ' + getCookie("swaggercookie_key") + '</li>');
   </div>
 </div>
  <button type="submit" class="btn btn-default" id="submit" >Submit</button>
+<hr>
 </form>
+<button type="button" class="btn btn-primary btn-lg" onclick="toggler('apigee')">Update Apigee Information</button>
+<form id="apigee" style="display:none">
+<div class="form-group row">
+  <label for="example-text-input" class="col-xs-2 col-form-label">Apigee API Target</label>
+  <div class="col-xs-10">
+    <input class="form-control" type="text" placeholder="https://api.enterprise.apigee.com/v1/o/org/environments/env/stats/apis" required  id="target">
+  </div>
+</div>
+<div class="form-group row">
+  <label for="example-text-input" class="col-xs-2 col-form-label">Apigee Credientials</label>
+  <div class="col-xs-10">
+    <input class="form-control" type="text" placeholder="base64.encode(username:password)" required  id="base64">
+  </div>
+</div>
+ <button type="submit" class="btn btn-default" id="submit" >Submit</button>
+</form>
+ <hr>
  <h4>Delete existing data:</h4>
  <button type="button" class="btn btn-default" id="clear" >Clear Credientials</button>
 </div>

--- a/dist/swaggerhub.php
+++ b/dist/swaggerhub.php
@@ -3,7 +3,7 @@
     <h4>SwaggerHub APIs</h4>
     <script>
         values = {};
-        makeCorsRequest(getCookie("swaggercookie_url"), getCookie("swaggercookie_key"), function(val) {
+        makeCorsRequest(getCookie("swaggercookie_url"), getCookie("swaggercookie_key"), "swaggerhub", function(val) {
             for (var count = 0; count < Object.keys(val['apis']).length; count++) {
                 var private_item = val['apis'][count]["properties"].length - 1;
                 $("#swaggerhub-list").append('<div class="list-group-item" id = "' + val['apis'][count]["name"] + '_' + val['apis'][count]["properties"][private_item]["value"] + '">' + val['apis'][count]["name"] + '<i class="fa fa-angle-right"></i></div>');


### PR DESCRIPTION
Users may only be interested in one API method at any given time, and the fact that you have to manually navigate to the correct API is tedious. Ideally, the portal should be able to automatically navigate you not only to the right API but also the right method.

This request also contains the first integration for API analytics. The first one used is Apigee analytics, but there is room for others as well.